### PR TITLE
fixed some bugs in the output logic

### DIFF
--- a/output.hpp
+++ b/output.hpp
@@ -211,6 +211,7 @@ void writeSnapshots(int isSecondary, metadata &sim, cosmology &cosmo, double avg
 		else
 			phi->saveHDF5(h5filename + filename + "_phi.h5");
 #endif
+	}
 		//-------------------Modification----------------------------
 		if (out_snapshot & MASK_ACHI && sim.aMG <= a)
 		{
@@ -438,7 +439,6 @@ void writeSnapshots(int isSecondary, metadata &sim, cosmology &cosmo, double avg
 #ifdef EXTERNAL_IO
 		ioserver.closeOstream();
 #endif
-	}
 }
 void writeAnimation(metadata &sim, cosmology &cosmo, double avgsource, const double fourpiG,
 					const double a, const double dtau_old, const int animcount, string h5filename,

--- a/parser.hpp
+++ b/parser.hpp
@@ -722,15 +722,15 @@ bool parseFieldSpecifiers(parameter *&params, const int numparam, const char *pn
 				pvalue |= MASK_ACHI;
 			else if (strcmp(start, "Aq") == 0 || strcmp(start, "aq") == 0)
 				pvalue |= MASK_AQ;
-			else if (strcmp(item, "T00_As") == 0 || strcmp(item, "T00_as") == 0)
+			else if (strcmp(start, "T00_As") == 0 || strcmp(start, "T00_as") == 0)
 				pvalue |= MASK_T00_AS;
-			else if (strcmp(item, "eos_As") == 0 || strcmp(item, "eos_as") == 0)
+			else if (strcmp(start, "eos_As") == 0 || strcmp(start, "eos_as") == 0)
 				pvalue |= MASK_EOS_AS;
-			else if (strcmp(item, "source") == 0 || strcmp(item, "rhocdm") == 0)
+			else if (strcmp(start, "source") == 0 || strcmp(start, "rhocdm") == 0)
 				pvalue |= MASK_SOURCE;
-			else if (strcmp(item, "hij_prime") == 0 || strcmp(item, "HIJ_PRIME") == 0)
+			else if (strcmp(start, "hij_prime") == 0 || strcmp(start, "HIJ_PRIME") == 0)
 				pvalue |= MASK_HIJPRIME;
-			else if (strcmp(item, "hij_prime_norm") == 0 || strcmp(item, "HIJ_PRIME_NORM") == 0)
+			else if (strcmp(start, "hij_prime_norm") == 0 || strcmp(start, "HIJ_PRIME_NORM") == 0)
 				pvalue |= MASK_HIJPRIMENORM;
 			/*--------------------------------------------*/
 			else if (strcmp(start, "Chi") == 0 || strcmp(start, "chi") == 0)


### PR DESCRIPTION
When some new output options were added in the parser, there was a copy-paste error in the function that breaks the list of outputs down into its elements - this resulted in the last element sometimes missing in the output.

The output logic itself had a misplaced bracket (possibly another copy-paste error), leading to most of the output being nested inside the scope of the "phi" output. If no "phi" was requested, most output would therefore not occur at all.